### PR TITLE
twbotのlog4jsのバージョンUP

### DIFF
--- a/lib/twbot.js
+++ b/lib/twbot.js
@@ -51,7 +51,7 @@ function TwBot(auth, options){
     }
   }
   this._options = options;
-  this._logger  = require('log4js')().getLogger(options.logger);
+  this._logger  = require('log4js').getLogger(options.logger);
   this._version = VERSION;
 }
 util.inherits(TwBot, EventEmitter);

--- a/lib/twbot.js
+++ b/lib/twbot.js
@@ -51,7 +51,7 @@ function TwBot(auth, options){
     }
   }
   this._options = options;
-  this._logger  = options.logger || require('log4js')().getLogger('twitter');
+  this._logger  = require('log4js')().getLogger(options.logger);
   this._version = VERSION;
 }
 util.inherits(TwBot, EventEmitter);

--- a/lib/twitter/index.js
+++ b/lib/twitter/index.js
@@ -55,7 +55,7 @@ function Twitter(consumerKey, consumerSecret, options){
   this._accessKey = options.accessKey;
   this._accessSecret = options.accessSecret;
 
-  this._logger = options.logger || require('log4js')().getLogger('twitter');
+  this._logger = options.logger || require('log4js').getLogger('twitter');
 };
 
 exports.createClient = function(consumerKey, consumerSecret, options){

--- a/lib/twitter/stream.js
+++ b/lib/twitter/stream.js
@@ -7,7 +7,7 @@
  */
 
 var EventEmitter = require('events').EventEmitter;
-var logger = require('log4js')().getLogger('twitter');
+var logger = require('log4js').getLogger('twitter');
 var buildUrl = require('../util').buildUrl;
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "contributors" : [],
     "dependencies" : {
         "oauth" : "= 0.9.0",
-        "log4js" : "= 0.2.6"
+        "log4js" : "= 0.5.2"
     },
     "main": "./lib/twbot",
     "bin" : {
@@ -28,6 +28,6 @@
         "url" : "http://github.com/yssk22/node-twbot/raw/master/LICENSE"
     }],
     "engines" : {
-        "node" : ">= 0.4.0"
+        "node" : ">= 0.8.4"
     }
 }


### PR DESCRIPTION
初めまして。
下記のNode.jsのユーザグループのページを見て、Node.jsを勉強していました。
http://dl.dropbox.com/u/219436/node.js/handson/build/html/webapp/websocket.html

twbotを使ったサンプルを組んでいたところ、以下の様なエラーが出てきました。

```
Error: require.paths is removed. Use node_modules folders, or the NODE_PATH environment variable instead.
    at Function.Module._compile.Object.defineProperty.get (module.js:386:11)
    at module.exports (/Users/node_modules/twbot/node_modules/log4js/lib/log4js.js:532:41)
    at new Twitter (/Users/node_modules/twbot/lib/twitter/index.js:58:53)
```

twbotのlog4jsのバージョンが古く動かないと判断したため、バージョンを上げました。
テストコードがなくて申し訳ないです。

動作確認環境は下記のとおりです。
Node.js 0.8.14
log4js 0.5.2

おかしな所があればご指摘いただけると幸いです。
